### PR TITLE
Add ZipArchive in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
     name: "ZipArchive",
+    products: [
+        .library(name: "ZipArchive", targets: ["ZipArchive"]),
+    ],
     targets: [
         .target(name: "ZipArchive", dependencies: ["CoreZipArchive"]),
         .target(name: "CoreZipArchive"),


### PR DESCRIPTION
I needed to add a product specification to be able to generate an Xcode project with Swift PM.